### PR TITLE
Fix onboarding flow after email verification

### DIFF
--- a/src/screens/auth/EmailVerificationScreen.tsx
+++ b/src/screens/auth/EmailVerificationScreen.tsx
@@ -43,8 +43,8 @@ export default function EmailVerificationScreen({
           if (isVerified) {
             setVerificationStatus('verified');
             setIsPolling(false);
-            // Navigate to guided first steps
-            navigation.replace('GuidedSteps');
+            // Don't navigate manually - let AuthStack handle it based on auth state
+            // The AuthStack will automatically navigate based on needsOnboarding state
           } else {
             setVerificationStatus('waiting');
           }


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix authentication and onboarding flow to prevent users from getting stuck on verification or tutorial screens.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, manual navigation in `EmailVerificationScreen` conflicted with the `AuthStack`'s state-driven navigation. Additionally, new user profiles were not always initialized with the `has_completed_onboarding: false` flag, and the `completeOnboarding` function had a delay in updating the local state. This PR ensures profiles are created correctly upon signup, `completeOnboarding` immediately updates local state, and navigation relies solely on the `AuthStack`'s conditional rendering based on authentication and onboarding status.

---
<a href="https://cursor.com/background-agent?bcId=bc-b6835f53-9d01-4bec-98ab-07d388883204">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b6835f53-9d01-4bec-98ab-07d388883204">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>