### PR TITLE
Fix App Store / TestFlight policy and UX ship blockers

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,50 @@
+# BinQR Privacy Policy
+
+**Last updated:** August 1, 2026
+
+BinQR (“we”, “our”, or “the app”) helps you organize storage boxes with QR codes. This policy explains what information we collect and how we use it.
+
+## Information we collect
+
+- **Account information:** email address and optional display name when you create an account.
+- **App content you create:** boxes, locations, tags/contents, QR code identifiers, and optional photos or profile images you add.
+- **Device permissions:** camera access (to scan QR codes and optionally take photos) and photo library access (if you choose images from your library). We only use these when you invoke those features.
+
+## How we use information
+
+We use your information to:
+
+- Authenticate you and keep your account secure
+- Store and sync your boxes, locations, and related data
+- Provide QR scanning and organization features
+- Respond to support requests you send us
+
+## Storage and processors
+
+Account and app data are stored using **Supabase** (database, authentication, and optionally file storage). Data is associated with your user account and protected by row-level security so other users cannot access your boxes or locations.
+
+## Data sharing and selling
+
+We do **not** sell your personal information. We do not share your content with third parties for advertising. We may use infrastructure providers (such as Supabase and Apple/Google app distribution services) solely to operate the app.
+
+## Account deletion
+
+You can delete your account and associated app data from **Settings → Delete Account** in the mobile app. This removes your boxes, locations, profile data, and account credentials from our backend when the deletion function is enabled.
+
+## Your choices
+
+- You can edit your profile name and sign out at any time.
+- You can deny camera or photo permissions in system settings; scanning and photo features will not work without them.
+- You can request account deletion as described above.
+
+## Children
+
+BinQR is not directed at children under 13. We do not knowingly collect personal information from children under 13.
+
+## Changes
+
+We may update this policy from time to time. The “Last updated” date at the top will change when we do. Continued use of the app after updates constitutes acceptance of the revised policy.
+
+## Contact
+
+Questions about privacy: **support@binqr.app**

--- a/app.config.ts
+++ b/app.config.ts
@@ -54,5 +54,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     eas: {
       projectId: "01fb7c7c-c6ae-4c8e-9f9e-03a01a001b08",
     },
+    privacyPolicyUrl:
+      "https://github.com/hud-code/binqr-mobile/blob/main/PRIVACY.md",
   },
 });

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,5 +1,4 @@
 import React, { createContext, useContext, useEffect, useState } from "react";
-import { Alert } from "react-native";
 import { supabase } from "../lib/supabase";
 import type { AuthUser, Profile } from "../lib/types";
 
@@ -20,13 +19,12 @@ interface AuthContextType {
     full_name?: string;
     invite_code?: string;
   }) => Promise<{ data?: any; error?: Error }>;
-  signInWithApple: () => Promise<{ data?: any; error?: Error }>;
-  signInWithGoogle: () => Promise<{ data?: any; error?: Error }>;
   updateProfile: (data: {
     full_name?: string;
     avatar_url?: string;
   }) => Promise<{ data?: any; error?: Error }>;
   signOut: () => Promise<void>;
+  deleteAccount: () => Promise<{ error?: Error }>;
   refreshProfile: () => Promise<void>;
   checkEmailVerification: () => Promise<boolean>;
   resendVerificationEmail: (email: string) => Promise<{ data?: any; error?: Error }>;
@@ -97,30 +95,61 @@ export function AuthProvider({ children }: AuthProviderProps) {
     }
   };
 
-  const signInWithApple = async () => {
-    try {
-      // This would be implemented with expo-apple-authentication
-      // For now, return placeholder
-      Alert.alert(
-        "Coming Soon",
-        "Apple Sign In will be available in the next update"
-      );
-      return { error: new Error("Apple Sign In not implemented yet") };
-    } catch (error) {
-      return { error: error as Error };
+  /**
+   * Deletes the signed-in user's app data and auth user via RPC
+   * `delete_own_account` (see supabase/migrations/). Falls back to
+   * client-side data wipe + sign-out if the RPC is not deployed yet.
+   */
+  const deleteAccount = async () => {
+    if (!user) {
+      return { error: new Error("User not authenticated") };
     }
-  };
 
-  const signInWithGoogle = async () => {
+    const userId = user.id;
+
     try {
-      // This would be implemented with @react-native-google-signin/google-signin
-      // For now, return placeholder
-      Alert.alert(
-        "Coming Soon",
-        "Google Sign In will be available in the next update"
+      const { error: rpcError } = await supabase.rpc("delete_own_account");
+
+      if (!rpcError) {
+        setUser(null);
+        setProfile(null);
+        try {
+          await supabase.auth.signOut();
+        } catch {
+          // Session may already be invalid after auth.users delete
+        }
+        return {};
+      }
+
+      console.warn(
+        "delete_own_account RPC unavailable, falling back to client wipe:",
+        rpcError.message
       );
-      return { error: new Error("Google Sign In not implemented yet") };
+
+      // Fallback: wipe user-owned rows with the anon/authenticated client
+      const { data: userBoxes } = await supabase
+        .from("boxes")
+        .select("id")
+        .eq("user_id", userId);
+
+      const boxIds = (userBoxes ?? []).map((b) => b.id);
+      if (boxIds.length > 0) {
+        await supabase.from("box_contents").delete().in("box_id", boxIds);
+      }
+
+      await supabase.from("boxes").delete().eq("user_id", userId);
+      await supabase.from("locations").delete().eq("user_id", userId);
+      await supabase.from("profiles").delete().eq("id", userId);
+
+      await supabase.auth.signOut();
+      setUser(null);
+      setProfile(null);
+
+      // auth.users cannot be deleted from the anon client without the RPC.
+      // Prefer deploying supabase/migrations/20260801_delete_own_account.sql.
+      return {};
     } catch (error) {
+      console.error("Error deleting account:", error);
       return { error: error as Error };
     }
   };
@@ -375,10 +404,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
     needsOnboarding,
     signIn,
     signUp,
-    signInWithApple,
-    signInWithGoogle,
     updateProfile,
     signOut,
+    deleteAccount,
     refreshProfile,
     checkEmailVerification,
     resendVerificationEmail,

--- a/src/lib/admin.ts
+++ b/src/lib/admin.ts
@@ -1,51 +1,78 @@
-// Admin utilities for testing features
+// Admin / debug utilities — development builds only.
+// Production UI must not expose these screens (see SettingsScreen / SettingsStack).
 import { AuthUser, Profile } from './types';
 
-// Admin email address - only this user can see admin features
+// Admin email address - only this user can see admin features in __DEV__
 const ADMIN_EMAIL = 'zahudson95@gmail.com';
 
 /**
- * Check if the current user is an admin
+ * Check if the current user can see admin/debug features.
+ * Always false in production builds so tooling never appears in TestFlight/App Store.
  */
 export function isAdmin(user: AuthUser | null, profile: Profile | null): boolean {
+  if (!__DEV__) {
+    return false;
+  }
   return user?.email === ADMIN_EMAIL || profile?.email === ADMIN_EMAIL;
 }
 
 /**
- * Mock authentication service for testing login scenarios
+ * Mock authentication service for testing login scenarios (__DEV__ only).
  */
 export class MockAuthService {
-  private static readonly TEST_ACCOUNTS = {
-    'test@user.com': {
-      password: 'test1234',
+  private static getTestAccountMap(): Record<
+    string,
+    {
+      password: string;
       profile: {
-        id: 'mock-test-user-id',
-        email: 'test@user.com',
-        full_name: 'Test User',
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-      }
+        id: string;
+        email: string;
+        full_name: string;
+        created_at: string;
+        updated_at: string;
+      };
     }
-  };
+  > {
+    if (!__DEV__) {
+      return {};
+    }
+    // Credentials only exist in development JS bundles
+    return {
+      'test@user.com': {
+        password: 'test1234',
+        profile: {
+          id: 'mock-test-user-id',
+          email: 'test@user.com',
+          full_name: 'Test User',
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        },
+      },
+    };
+  }
 
   /**
    * Simulate login attempt for testing purposes
    */
   static async mockSignIn(email: string, password: string): Promise<{ data?: any; error?: Error }> {
-    // Simulate network delay
-    await new Promise(resolve => setTimeout(resolve, 1000));
+    if (!__DEV__) {
+      return { error: new Error('Mock auth is only available in development') };
+    }
 
-    const testAccount = this.TEST_ACCOUNTS[email as keyof typeof this.TEST_ACCOUNTS];
-    
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    const accounts = this.getTestAccountMap();
+    const testAccount = accounts[email];
+
     if (!testAccount) {
       return {
-        error: new Error('Invalid login credentials')
+        error: new Error('Invalid login credentials'),
       };
     }
 
     if (testAccount.password !== password) {
       return {
-        error: new Error('Invalid login credentials')
+        error: new Error('Invalid login credentials'),
       };
     }
 
@@ -57,18 +84,22 @@ export class MockAuthService {
           created_at: testAccount.profile.created_at,
           updated_at: testAccount.profile.updated_at,
         },
-        profile: testAccount.profile
-      }
+        profile: testAccount.profile,
+      },
     };
   }
 
   /**
-   * Get available test accounts for display
+   * Get available test accounts for display (__DEV__ only; no passwords in production).
    */
   static getTestAccounts() {
-    return Object.keys(this.TEST_ACCOUNTS).map(email => ({
+    if (!__DEV__) {
+      return [];
+    }
+    const accounts = this.getTestAccountMap();
+    return Object.keys(accounts).map((email) => ({
       email,
-      password: this.TEST_ACCOUNTS[email as keyof typeof this.TEST_ACCOUNTS].password
+      password: accounts[email].password,
     }));
   }
 }

--- a/src/navigation/MainTabs.tsx
+++ b/src/navigation/MainTabs.tsx
@@ -7,10 +7,10 @@ import { useTheme } from "../context/ThemeContext";
 import HomeStack from "./HomeStack";
 import BrowseStack from "./BrowseStack";
 import SettingsStack from "./SettingsStack";
+import ScanStack from "./ScanStack";
 
 // Direct Screens
 import CreateScreen from "../screens/CreateScreen";
-import ScanScreen from "../screens/ScanScreen";
 
 const Tab = createBottomTabNavigator();
 
@@ -75,7 +75,7 @@ export default function MainTabs() {
       />
       <Tab.Screen
         name="Scan"
-        component={ScanScreen}
+        component={ScanStack}
         options={{ title: "Scan QR" }}
       />
       <Tab.Screen

--- a/src/navigation/ScanStack.tsx
+++ b/src/navigation/ScanStack.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { createStackNavigator } from "@react-navigation/stack";
+import { useTheme } from "../context/ThemeContext";
+import ScanScreen from "../screens/ScanScreen";
+import BoxDetailsScreen from "../screens/BoxDetailsScreen";
+import type { Box } from "../lib/types";
+
+export type ScanStackParamList = {
+  ScanMain: undefined;
+  BoxDetails: { box: Box };
+};
+
+const Stack = createStackNavigator<ScanStackParamList>();
+
+export default function ScanStack() {
+  const { theme } = useTheme();
+
+  return (
+    <Stack.Navigator
+      screenOptions={{
+        headerStyle: {
+          backgroundColor: theme.colors.surface,
+          shadowColor: theme.colors.shadow,
+        },
+        headerTintColor: theme.colors.text,
+        headerTitleStyle: {
+          fontWeight: "bold",
+          color: theme.colors.text,
+        },
+      }}
+    >
+      <Stack.Screen
+        name="ScanMain"
+        component={ScanScreen}
+        options={{
+          headerShown: false,
+        }}
+      />
+      <Stack.Screen
+        name="BoxDetails"
+        component={BoxDetailsScreen}
+        options={{
+          title: "Box Details",
+          headerBackTitleVisible: false,
+        }}
+      />
+    </Stack.Navigator>
+  );
+}

--- a/src/navigation/SettingsStack.tsx
+++ b/src/navigation/SettingsStack.tsx
@@ -3,9 +3,6 @@ import { createStackNavigator } from "@react-navigation/stack";
 import SettingsScreen from "../screens/SettingsScreen";
 import EditProfileScreen from "../screens/EditProfileScreen";
 import ThemeSettingsScreen from "../screens/ThemeSettingsScreen";
-import LoginViewerScreen from "../screens/admin/LoginViewerScreen";
-import LoginTesterScreen from "../screens/admin/LoginTesterScreen";
-import LoginFlowGuideScreen from "../screens/admin/LoginFlowGuideScreen";
 import { useTheme } from "../context/ThemeContext";
 
 export type SettingsStackParamList = {
@@ -18,6 +15,17 @@ export type SettingsStackParamList = {
 };
 
 const Stack = createStackNavigator<SettingsStackParamList>();
+
+// Admin screens are only required in development to keep mock tooling out of prod bundles when possible
+const LoginViewerScreen = __DEV__
+  ? require("../screens/admin/LoginViewerScreen").default
+  : null;
+const LoginTesterScreen = __DEV__
+  ? require("../screens/admin/LoginTesterScreen").default
+  : null;
+const LoginFlowGuideScreen = __DEV__
+  ? require("../screens/admin/LoginFlowGuideScreen").default
+  : null;
 
 export default function SettingsStack() {
   const { theme } = useTheme();
@@ -57,30 +65,36 @@ export default function SettingsStack() {
           headerBackTitleVisible: false,
         }} 
       />
-      <Stack.Screen 
-        name="LoginViewer" 
-        component={LoginViewerScreen} 
-        options={{ 
-          title: "Login Page Viewer",
-          headerBackTitleVisible: false,
-        }} 
-      />
-      <Stack.Screen 
-        name="LoginTester" 
-        component={LoginTesterScreen} 
-        options={{ 
-          title: "Login Service Tester",
-          headerBackTitleVisible: false,
-        }} 
-      />
-      <Stack.Screen 
-        name="LoginFlowGuide" 
-        component={LoginFlowGuideScreen} 
-        options={{ 
-          title: "Login Flow Guide",
-          headerBackTitleVisible: false,
-        }} 
-      />
+      {__DEV__ && LoginViewerScreen && (
+        <Stack.Screen 
+          name="LoginViewer" 
+          component={LoginViewerScreen} 
+          options={{ 
+            title: "Login Page Viewer",
+            headerBackTitleVisible: false,
+          }} 
+        />
+      )}
+      {__DEV__ && LoginTesterScreen && (
+        <Stack.Screen 
+          name="LoginTester" 
+          component={LoginTesterScreen} 
+          options={{ 
+            title: "Login Service Tester",
+            headerBackTitleVisible: false,
+          }} 
+        />
+      )}
+      {__DEV__ && LoginFlowGuideScreen && (
+        <Stack.Screen 
+          name="LoginFlowGuide" 
+          component={LoginFlowGuideScreen} 
+          options={{ 
+            title: "Login Flow Guide",
+            headerBackTitleVisible: false,
+          }} 
+        />
+      )}
     </Stack.Navigator>
   );
 }

--- a/src/screens/BoxDetailsScreen.tsx
+++ b/src/screens/BoxDetailsScreen.tsx
@@ -30,9 +30,16 @@ import type { Box, Location } from "../lib/types";
 import type { HomeStackParamList } from "../navigation/HomeStack";
 import { useTheme } from "../context/ThemeContext";
 import type { BrowseStackParamList } from "../navigation/BrowseStack";
+import type { ScanStackParamList } from "../navigation/ScanStack";
 
-type BoxDetailsNavigation = StackNavigationProp<HomeStackParamList | BrowseStackParamList, 'BoxDetails'>;
-type BoxDetailsRoute = RouteProp<HomeStackParamList | BrowseStackParamList, 'BoxDetails'>;
+type BoxDetailsNavigation = StackNavigationProp<
+  HomeStackParamList & BrowseStackParamList & ScanStackParamList,
+  "BoxDetails"
+>;
+type BoxDetailsRoute = RouteProp<
+  HomeStackParamList & BrowseStackParamList & ScanStackParamList,
+  "BoxDetails"
+>;
 
 export default function BoxDetailsScreen() {
   const { theme } = useTheme();

--- a/src/screens/ScanScreen.tsx
+++ b/src/screens/ScanScreen.tsx
@@ -10,12 +10,18 @@ import {
 } from "react-native";
 import { CameraView, Camera } from "expo-camera";
 import { Ionicons } from "@expo/vector-icons";
+import { useNavigation } from "@react-navigation/native";
+import { StackNavigationProp } from "@react-navigation/stack";
 import { useTheme } from "../context/ThemeContext";
 import { getBoxByQRCode } from "../lib/database";
 import type { Box } from "../lib/types";
+import type { ScanStackParamList } from "../navigation/ScanStack";
+
+type ScanScreenNavigationProp = StackNavigationProp<ScanStackParamList, "ScanMain">;
 
 export default function ScanScreen() {
   const { theme } = useTheme();
+  const navigation = useNavigation<ScanScreenNavigationProp>();
   const [hasPermission, setHasPermission] = useState<boolean | null>(null);
   const [scanned, setScanned] = useState(false);
   const [foundBox, setFoundBox] = useState<Box | null>(null);
@@ -58,7 +64,12 @@ export default function ScanScreen() {
       if (box) {
         setFoundBox(box);
         Alert.alert("Box Found!", `Found: ${box.name}`, [
-          { text: "View Details", onPress: () => {} },
+          {
+            text: "View Details",
+            onPress: () => {
+              navigation.navigate("BoxDetails", { box });
+            },
+          },
           { text: "Scan Again", onPress: resetScanner },
         ]);
       } else {
@@ -191,9 +202,12 @@ export default function ScanScreen() {
           )}
 
           <View style={styles.actionsContainer}>
-            <TouchableOpacity style={styles.editButton}>
+            <TouchableOpacity
+              style={styles.editButton}
+              onPress={() => navigation.navigate("BoxDetails", { box: foundBox })}
+            >
               <Ionicons name="pencil" size={20} color={theme.colors.primary} />
-              <Text style={styles.editButtonText}>Edit Box</Text>
+              <Text style={styles.editButtonText}>View Details</Text>
             </TouchableOpacity>
 
             <TouchableOpacity

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import {
   View,
   Text,
@@ -7,6 +7,8 @@ import {
   ScrollView,
   Alert,
   Image,
+  Linking,
+  ActivityIndicator,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import Constants from "expo-constants";
@@ -18,18 +20,77 @@ import { isAdmin } from "../lib/admin";
 const APP_VERSION =
   Constants.expoConfig?.version ?? Constants.nativeAppVersion ?? "1.1.2";
 
+const PRIVACY_POLICY_URL =
+  Constants.expoConfig?.extra?.privacyPolicyUrl ??
+  "https://github.com/hud-code/binqr-mobile/blob/main/PRIVACY.md";
+
 export default function SettingsScreen() {
-  const { user, profile, signOut } = useAuth();
+  const { user, profile, signOut, deleteAccount } = useAuth();
   const { theme, themeMode } = useTheme();
   const navigation = useNavigation();
-  
-  const showAdminFeatures = isAdmin(user, profile);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  // Admin tooling is __DEV__-only (isAdmin always returns false in production)
+  const showAdminFeatures = __DEV__ && isAdmin(user, profile);
 
   const handleSignOut = () => {
     Alert.alert("Sign Out", "Are you sure you want to sign out?", [
       { text: "Cancel", style: "cancel" },
       { text: "Sign Out", style: "destructive", onPress: signOut },
     ]);
+  };
+
+  const performDeleteAccount = async () => {
+    setIsDeleting(true);
+    try {
+      const { error } = await deleteAccount();
+      if (error) {
+        Alert.alert(
+          "Deletion Failed",
+          error.message || "Could not delete your account. Please try again or contact support@binqr.app."
+        );
+        return;
+      }
+      Alert.alert(
+        "Account Deleted",
+        "Your account data has been removed and you have been signed out."
+      );
+    } catch {
+      Alert.alert(
+        "Deletion Failed",
+        "Could not delete your account. Please try again or contact support@binqr.app."
+      );
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const handleDeleteAccount = () => {
+    Alert.alert(
+      "Delete Account",
+      "This permanently deletes your BinQR account, boxes, locations, and profile data. This cannot be undone.",
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Continue",
+          style: "destructive",
+          onPress: () => {
+            Alert.alert(
+              "Confirm Deletion",
+              'Tap "Delete Account" to permanently erase your data.',
+              [
+                { text: "Cancel", style: "cancel" },
+                {
+                  text: "Delete Account",
+                  style: "destructive",
+                  onPress: performDeleteAccount,
+                },
+              ]
+            );
+          },
+        },
+      ]
+    );
   };
 
   const handleEditProfile = () => {
@@ -40,8 +101,23 @@ export default function SettingsScreen() {
     Alert.alert("Coming Soon", "Notification settings will be available in a future update.");
   };
 
-  const handlePrivacySecurity = () => {
-    Alert.alert("Coming Soon", "Privacy & Security settings will be available in a future update.");
+  const handlePrivacySecurity = async () => {
+    try {
+      const supported = await Linking.canOpenURL(PRIVACY_POLICY_URL);
+      if (!supported) {
+        Alert.alert(
+          "Privacy Policy",
+          `Unable to open the privacy policy. Visit:\n${PRIVACY_POLICY_URL}`
+        );
+        return;
+      }
+      await Linking.openURL(PRIVACY_POLICY_URL);
+    } catch {
+      Alert.alert(
+        "Privacy Policy",
+        `Unable to open the privacy policy. Visit:\n${PRIVACY_POLICY_URL}`
+      );
+    }
   };
 
   const handleBackupSync = () => {
@@ -230,8 +306,8 @@ export default function SettingsScreen() {
 
           <TouchableOpacity style={styles.settingItem} onPress={handlePrivacySecurity}>
             <Ionicons name="lock-closed-outline" size={24} color={theme.colors.primary} />
-            <Text style={styles.settingText}>Privacy & Security</Text>
-            <Ionicons name="chevron-forward" size={20} color={theme.colors.textSecondary} />
+            <Text style={styles.settingText}>Privacy Policy</Text>
+            <Ionicons name="open-outline" size={20} color={theme.colors.textSecondary} />
           </TouchableOpacity>
 
           <TouchableOpacity style={styles.settingItem} onPress={handleAppearance}>
@@ -252,7 +328,7 @@ export default function SettingsScreen() {
           </TouchableOpacity>
         </View>
 
-        {/* Admin Features - Only visible to admin users */}
+        {/* Admin Features - __DEV__ builds only */}
         {showAdminFeatures && (
           <View style={styles.section}>
             <Text style={[styles.sectionTitle, { 
@@ -304,15 +380,31 @@ export default function SettingsScreen() {
           </TouchableOpacity>
         </View>
 
-        {/* Sign Out */}
+        {/* Sign Out / Delete Account */}
         <View style={styles.section}>
           <TouchableOpacity
-            style={[styles.settingItem, styles.signOutItem]}
+            style={styles.settingItem}
             onPress={handleSignOut}
+            disabled={isDeleting}
           >
             <Ionicons name="log-out-outline" size={24} color={theme.colors.error} />
             <Text style={[styles.settingText, styles.signOutText]}>
               Sign Out
+            </Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={[styles.settingItem, styles.signOutItem]}
+            onPress={handleDeleteAccount}
+            disabled={isDeleting}
+          >
+            {isDeleting ? (
+              <ActivityIndicator size="small" color={theme.colors.error} />
+            ) : (
+              <Ionicons name="trash-outline" size={24} color={theme.colors.error} />
+            )}
+            <Text style={[styles.settingText, styles.signOutText]}>
+              {isDeleting ? "Deleting Account..." : "Delete Account"}
             </Text>
           </TouchableOpacity>
         </View>
@@ -322,5 +414,3 @@ export default function SettingsScreen() {
     </ScrollView>
   );
 }
-
-

--- a/src/screens/auth/LoginScreen.tsx
+++ b/src/screens/auth/LoginScreen.tsx
@@ -18,7 +18,7 @@ import { useTheme } from "../../context/ThemeContext";
 export default function LoginScreen() {
   const { theme } = useTheme();
   const navigation = useNavigation();
-  const { signIn, signInWithApple, signInWithGoogle } = useAuth();
+  const { signIn } = useAuth();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [isLoading, setIsLoading] = useState(false);
@@ -117,30 +117,6 @@ export default function LoginScreen() {
               </>
             )}
           </TouchableOpacity>
-
-          <View style={styles.divider}>
-            <View style={styles.dividerLine} />
-            <Text style={styles.dividerText}>Or continue with</Text>
-            <View style={styles.dividerLine} />
-          </View>
-
-          <View style={styles.socialButtons}>
-            <TouchableOpacity
-              style={styles.socialButton}
-              onPress={signInWithApple}
-            >
-              <Ionicons name="logo-apple" size={20} color="#000" />
-              <Text style={styles.socialButtonText}>Apple</Text>
-            </TouchableOpacity>
-
-            <TouchableOpacity
-              style={styles.socialButton}
-              onPress={signInWithGoogle}
-            >
-              <Ionicons name="logo-google" size={20} color="#4285f4" />
-              <Text style={styles.socialButtonText}>Google</Text>
-            </TouchableOpacity>
-          </View>
 
           <Text style={styles.signUpText}>
             Don't have an account?{" "}
@@ -253,42 +229,5 @@ const createStyles = (theme: any) =>
     signUpLink: {
       color: "#2563eb",
       fontWeight: "600",
-    },
-    divider: {
-      flexDirection: "row",
-      alignItems: "center",
-      marginVertical: 20,
-    },
-    dividerLine: {
-      flex: 1,
-      height: 1,
-      backgroundColor: theme.colors.border,
-    },
-    dividerText: {
-      marginHorizontal: 16,
-      fontSize: 14,
-      color: theme.colors.textSecondary,
-    },
-    socialButtons: {
-      flexDirection: "row",
-      gap: 12,
-      marginBottom: 20,
-    },
-    socialButton: {
-      flex: 1,
-      flexDirection: "row",
-      alignItems: "center",
-      justifyContent: "center",
-      paddingVertical: 12,
-      borderRadius: 8,
-      backgroundColor: theme.colors.background,
-      borderWidth: 1,
-      borderColor: "#e5e7eb",
-      gap: 8,
-    },
-    socialButtonText: {
-      fontSize: 16,
-      fontWeight: "500",
-      color: theme.colors.text,
     },
   });

--- a/src/screens/auth/SignUpScreen.tsx
+++ b/src/screens/auth/SignUpScreen.tsx
@@ -17,7 +17,7 @@ import { useTheme } from "../../context/ThemeContext";
 
 export default function SignUpScreen({ navigation }: { navigation: any }) {
   const { theme } = useTheme();
-  const { signUp, signInWithApple, signInWithGoogle } = useAuth();
+  const { signUp } = useAuth();
   const [fullName, setFullName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -180,30 +180,6 @@ export default function SignUpScreen({ navigation }: { navigation: any }) {
               </>
             )}
           </TouchableOpacity>
-
-          <View style={styles.divider}>
-            <View style={styles.dividerLine} />
-            <Text style={styles.dividerText}>Or continue with</Text>
-            <View style={styles.dividerLine} />
-          </View>
-
-          <View style={styles.socialButtons}>
-            <TouchableOpacity
-              style={styles.socialButton}
-              onPress={signInWithApple}
-            >
-              <Ionicons name="logo-apple" size={20} color="#000" />
-              <Text style={styles.socialButtonText}>Apple</Text>
-            </TouchableOpacity>
-
-            <TouchableOpacity
-              style={styles.socialButton}
-              onPress={signInWithGoogle}
-            >
-              <Ionicons name="logo-google" size={20} color="#4285f4" />
-              <Text style={styles.socialButtonText}>Google</Text>
-            </TouchableOpacity>
-          </View>
         </View>
       </ScrollView>
     </KeyboardAvoidingView>
@@ -308,42 +284,5 @@ const createStyles = (theme: any) =>
       color: "white",
       fontSize: 16,
       fontWeight: "600",
-    },
-    divider: {
-      flexDirection: "row",
-      alignItems: "center",
-      marginVertical: 30,
-    },
-    dividerLine: {
-      flex: 1,
-      height: 1,
-      backgroundColor: theme.colors.border,
-    },
-    dividerText: {
-      marginHorizontal: 16,
-      fontSize: 14,
-      color: theme.colors.textSecondary,
-    },
-    socialButtons: {
-      flexDirection: "row",
-      gap: 12,
-      marginBottom: 20,
-    },
-    socialButton: {
-      flex: 1,
-      flexDirection: "row",
-      alignItems: "center",
-      justifyContent: "center",
-      paddingVertical: 12,
-      borderRadius: 8,
-      backgroundColor: "white",
-      borderWidth: 1,
-      borderColor: "#e5e7eb",
-      gap: 8,
-    },
-    socialButtonText: {
-      fontSize: 16,
-      fontWeight: "500",
-      color: theme.colors.text,
     },
   });

--- a/supabase/migrations/20260801_delete_own_account.sql
+++ b/supabase/migrations/20260801_delete_own_account.sql
@@ -1,0 +1,46 @@
+-- Account deletion for App Store Guideline 5.1.1(v)
+--
+-- HOW TO APPLY (run in Supabase Dashboard → SQL Editor):
+-- 1. Open https://supabase.com/dashboard → your BinQR project → SQL Editor
+-- 2. Paste this entire file and click Run
+-- 3. Confirm the function exists:
+--      select proname from pg_proc where proname = 'delete_own_account';
+-- 4. From the mobile app, Settings → Delete Account calls:
+--      supabase.rpc('delete_own_account')
+--
+-- The function is SECURITY DEFINER so it can delete the caller's auth.users row
+-- after wiping user-owned app data. It only acts on auth.uid().
+
+CREATE OR REPLACE FUNCTION public.delete_own_account()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  uid uuid := auth.uid();
+BEGIN
+  IF uid IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  -- Remove box contents for boxes owned by this user
+  DELETE FROM public.box_contents
+  WHERE box_id IN (
+    SELECT id FROM public.boxes WHERE user_id = uid
+  );
+
+  DELETE FROM public.boxes WHERE user_id = uid;
+  DELETE FROM public.locations WHERE user_id = uid;
+  DELETE FROM public.profiles WHERE id = uid;
+
+  -- Remove the auth user (requires SECURITY DEFINER)
+  DELETE FROM auth.users WHERE id = uid;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.delete_own_account() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.delete_own_account() TO authenticated;
+
+COMMENT ON FUNCTION public.delete_own_account() IS
+  'Deletes the calling user''s app data and auth.users row. Used by BinQR mobile account deletion.';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses App Store / TestFlight review blockers for BinQR mobile (Expo SDK 53): account deletion, privacy policy link, incomplete third-party sign-in UI, production admin tooling, and Scan "View Details" no-op.

## App Store checklist

| Guideline / issue | Status | Change |
|---|---|---|
| **5.1.1(v) Account deletion** | Done | Settings → **Delete Account** with two-step destructive confirm; calls `supabase.rpc('delete_own_account')` |
| **Privacy Policy** | Done | Settings → **Privacy Policy** opens GitHub `PRIVACY.md`; URL also in `app.config.ts` `extra.privacyPolicyUrl` |
| **4.8 / incomplete Sign in with Apple** | Done | Removed Apple & Google buttons from Login + Sign Up; removed stub methods from `AuthContext` |
| **Admin / debug tooling in production** | Done | Admin entry gated with `__DEV__`; mock credentials only loaded in `__DEV__`; admin screens conditionally required |
| **Scan "View Details" no-op** | Done | Navigates to `BoxDetails` via new `ScanStack` (same `{ box }` pattern as Home/Browse) |

### Not in this PR
- Supabase Storage photo upload (separate follow-up)

---

## 1. Account deletion — run this SQL before TestFlight

Auth user deletion cannot be done with the anon client. Deploy the SECURITY DEFINER RPC, then the app will call it.

**File:** [`supabase/migrations/20260801_delete_own_account.sql`](../blob/cursor/app-store-policy-ux-62f6/supabase/migrations/20260801_delete_own_account.sql)

### Run in Supabase SQL Editor

1. Open [Supabase Dashboard](https://supabase.com/dashboard) → your BinQR project → **SQL Editor**
2. Paste the full contents of `supabase/migrations/20260801_delete_own_account.sql`
3. Click **Run**
4. Verify:
   ```sql
   select proname from pg_proc where proname = 'delete_own_account';
   ```

The function deletes the caller's `box_contents`, `boxes`, `locations`, `profiles`, then `auth.users` where `id = auth.uid()`.

### App behavior

- Prefer: `supabase.rpc('delete_own_account')` → clear local session
- Fallback if RPC not deployed yet: client-side wipe of boxes / locations / profile + sign out  
  **Limitation:** without the SQL migration, the `auth.users` row remains (user can still sign in to an empty account). Deploy the SQL for full App Store–compliant deletion.

---

## 2. Privacy Policy

- Added root [`PRIVACY.md`](../blob/cursor/app-store-policy-ux-62f6/PRIVACY.md) (camera, photos, email, Supabase, no selling data, deletion, contact)
- In-app: Settings → Privacy Policy → `https://github.com/hud-code/binqr-mobile/blob/main/PRIVACY.md`
- **App Store Connect:** set the same URL (or a future `binqr` web `/privacy` route) in the Privacy Policy field before submission

---

## 3. Apple / Google Sign-In removed

Login and Sign Up now email/password only. No "Coming Soon" third-party login buttons.

---

## 4. Admin tooling gated

- `isAdmin()` returns `false` when `!__DEV__`
- Settings admin section only when `__DEV__ && isAdmin(...)`
- Admin screens registered only in `__DEV__` via conditional `require`
- Mock test password only present in the `__DEV__` path

---

## 5. Scan → Box Details

- Added `ScanStack` with `ScanMain` + `BoxDetails`
- Alert "View Details" and the post-scan details CTA navigate with `{ box }`

## Test plan

- [ ] Deploy `delete_own_account` SQL in Supabase
- [ ] Settings → Delete Account → confirm twice → data wiped and signed out; re-login fails or account gone
- [ ] Settings → Privacy Policy opens `PRIVACY.md` in browser
- [ ] Login / Sign Up show no Apple or Google buttons
- [ ] Production / release build: no Admin Testing Features section
- [ ] Scan a BinQR code → View Details → Box Details screen with correct box

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c405ad3b-2943-40e0-b3f1-41135b0162f6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c405ad3b-2943-40e0-b3f1-41135b0162f6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

