### PR TITLE
Add Supabase Storage photo uploads and env docs for new project

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,10 @@
 # Copy to .env for local development (do not commit .env).
 # For EAS builds, set these as EAS Secrets / project environment variables
 # (see README — Production / EAS section).
+#
+# Current BinQR Supabase project ref: yezhteuapxqomspindaz
+# EXPO_PUBLIC_SUPABASE_URL=https://yezhteuapxqomspindaz.supabase.co
+# EXPO_PUBLIC_SUPABASE_ANON_KEY=<anon key from Supabase Dashboard → Settings → API>
 
-EXPO_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
-EXPO_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
+EXPO_PUBLIC_SUPABASE_URL=
+EXPO_PUBLIC_SUPABASE_ANON_KEY=

--- a/README.md
+++ b/README.md
@@ -20,13 +20,23 @@ A React Native app for organizing storage boxes with QR codes, built with Expo.
    npm install
    ```
 
-2. **Configure Supabase:**
+2. **Configure Supabase (local `.env`):**
 
-   - Copy `.env.example` to `.env` (`.env` is gitignored) and fill in:
-     ```
-     EXPO_PUBLIC_SUPABASE_URL=your_supabase_url
-     EXPO_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
-     ```
+   Create an untracked local env file (never commit secrets):
+
+   ```bash
+   cp .env.example .env
+   ```
+
+   Then set both values in `.env` from the Supabase Dashboard
+   (**Settings → API**) for project ref `yezhteuapxqomspindaz`:
+
+   ```
+   EXPO_PUBLIC_SUPABASE_URL=https://yezhteuapxqomspindaz.supabase.co
+   EXPO_PUBLIC_SUPABASE_ANON_KEY=<your_anon_key>
+   ```
+
+   Restart Expo after changing `.env` so `EXPO_PUBLIC_*` values reload.
 
 3. **Start development server:**
 
@@ -83,26 +93,33 @@ src/
 
 ### Environment Setup
 
-- Copy `.env.example` to `.env` for local development
-- Copy your web app's Supabase configuration into `.env`
+- Copy `.env.example` to `.env` for local development (`.env` is gitignored)
+- Point the app at Supabase project ref `yezhteuapxqomspindaz`
+- Put only the project URL and anon key in `.env` — never commit real keys
+- Box photos upload to the public `box-photos` Storage bucket at `{user_id}/{uuid}.{ext}`
 - Ensure database schema matches between web and mobile
 - Test authentication flow thoroughly
 
 ### Production / EAS
 
-App config lives in `app.config.ts` (including `extra.eas.projectId`). Do not commit secrets in `eas.json`.
+App config lives in `app.config.ts` (including `extra.eas.projectId`). Do not commit secrets in `eas.json` or `.env`.
 
-For EAS builds (TestFlight / production), set these as EAS Secrets or project environment variables in the Expo dashboard:
+For EAS builds (TestFlight / production), set the same two variables as EAS Secrets
+(or project environment variables) in the Expo dashboard / CLI so production
+builds hit project `yezhteuapxqomspindaz`:
 
 - `EXPO_PUBLIC_SUPABASE_URL`
 - `EXPO_PUBLIC_SUPABASE_ANON_KEY`
 
-Example:
+Example (replace the anon key with the value from Supabase Dashboard → Settings → API):
 
 ```bash
-eas secret:create --name EXPO_PUBLIC_SUPABASE_URL --value "https://your-project.supabase.co" --type string
-eas secret:create --name EXPO_PUBLIC_SUPABASE_ANON_KEY --value "your_supabase_anon_key" --type string
+eas secret:create --name EXPO_PUBLIC_SUPABASE_URL --value "https://yezhteuapxqomspindaz.supabase.co" --type string
+eas secret:create --name EXPO_PUBLIC_SUPABASE_ANON_KEY --value "<your_anon_key>" --type string
 ```
+
+List or update existing secrets with `eas secret:list` / `eas secret:delete` as needed.
+Do not paste real anon keys into git, README examples, or PR descriptions.
 
 ### Code Sharing with Web App
 

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,93 @@
+import { v4 as uuidv4 } from "uuid";
+import { supabase } from "./supabase";
+
+const BOX_PHOTOS_BUCKET = "box-photos";
+
+function getExtension(uri: string, mimeType?: string | null): string {
+  const fromUri = uri.split("?")[0].split(".").pop()?.toLowerCase();
+  if (fromUri && fromUri.length <= 5 && /^[a-z0-9]+$/.test(fromUri)) {
+    return fromUri === "jpeg" ? "jpg" : fromUri;
+  }
+  if (mimeType?.includes("png")) return "png";
+  if (mimeType?.includes("webp")) return "webp";
+  if (mimeType?.includes("gif")) return "gif";
+  return "jpg";
+}
+
+function getContentType(ext: string): string {
+  switch (ext) {
+    case "png":
+      return "image/png";
+    case "webp":
+      return "image/webp";
+    case "gif":
+      return "image/gif";
+    default:
+      return "image/jpeg";
+  }
+}
+
+/** Returns true when the URI still points at a local device file. */
+export function isLocalImageUri(uri: string): boolean {
+  return (
+    uri.startsWith("file://") ||
+    uri.startsWith("content://") ||
+    uri.startsWith("ph://") ||
+    uri.startsWith("assets-library://") ||
+    (!uri.startsWith("http://") && !uri.startsWith("https://"))
+  );
+}
+
+/**
+ * Upload a local box photo to Supabase Storage at
+ * `box-photos/{userId}/{uuid}.{ext}` and return its public URL.
+ * Remote http(s) URLs are returned unchanged.
+ */
+export async function uploadBoxPhoto(
+  localUri: string,
+  mimeType?: string | null
+): Promise<string> {
+  if (!isLocalImageUri(localUri)) {
+    return localUri;
+  }
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    throw new Error("You must be signed in to upload photos.");
+  }
+
+  const ext = getExtension(localUri, mimeType);
+  const path = `${user.id}/${uuidv4()}.${ext}`;
+  const contentType = getContentType(ext);
+
+  const response = await fetch(localUri);
+  if (!response.ok) {
+    throw new Error("Failed to read the photo from this device.");
+  }
+
+  const arrayBuffer = await response.arrayBuffer();
+  const { error: uploadError } = await supabase.storage
+    .from(BOX_PHOTOS_BUCKET)
+    .upload(path, arrayBuffer, {
+      contentType,
+      upsert: false,
+    });
+
+  if (uploadError) {
+    throw uploadError;
+  }
+
+  const { data } = supabase.storage
+    .from(BOX_PHOTOS_BUCKET)
+    .getPublicUrl(path);
+
+  if (!data?.publicUrl) {
+    throw new Error("Upload succeeded but no public URL was returned.");
+  }
+
+  return data.publicUrl;
+}

--- a/src/screens/BoxDetailsScreen.tsx
+++ b/src/screens/BoxDetailsScreen.tsx
@@ -26,6 +26,7 @@ import {
   generateNewQRCode,
   saveLocation,
 } from "../lib/database";
+import { isLocalImageUri, uploadBoxPhoto } from "../lib/storage";
 import type { Box, Location } from "../lib/types";
 import type { HomeStackParamList } from "../navigation/HomeStack";
 import { useTheme } from "../context/ThemeContext";
@@ -126,10 +127,27 @@ export default function BoxDetailsScreen() {
 
     setIsLoading(true);
     try {
+      // Upload any newly picked local photo before persisting image_url.
+      let photoUrls = editedBox.photo_urls || [];
+      const localPhoto = photoUrls.find((uri) => isLocalImageUri(uri));
+      if (localPhoto) {
+        try {
+          const publicUrl = await uploadBoxPhoto(localPhoto);
+          photoUrls = [publicUrl];
+        } catch (uploadError) {
+          console.error("Photo upload failed:", uploadError);
+          Alert.alert(
+            "Photo upload failed",
+            "Could not upload the new photo. Other box changes were not saved. Check your connection and try again."
+          );
+          return;
+        }
+      }
+
       console.log('Updating box with data:', {
         name: editedBox.name.trim(),
         description: editedBox.description?.trim(),
-        photo_urls: editedBox.photo_urls,
+        photo_urls: photoUrls,
         tags: editedBox.tags,
         location_id: editedBox.location_id,
       });
@@ -137,7 +155,7 @@ export default function BoxDetailsScreen() {
       const updatedBox = await updateBox(editedBox.id, {
         name: editedBox.name.trim(),
         description: editedBox.description?.trim(),
-        photo_urls: editedBox.photo_urls,
+        photo_urls: photoUrls,
         tags: editedBox.tags,
         location_id: editedBox.location_id,
       });

--- a/src/screens/CreateScreen.tsx
+++ b/src/screens/CreateScreen.tsx
@@ -16,6 +16,7 @@ import QRCode from "react-native-qrcode-svg";
 import { v4 as uuidv4 } from "uuid";
 
 import { getStoredLocations, saveBox, saveLocation } from "../lib/database";
+import { uploadBoxPhoto } from "../lib/storage";
 import type { Location, CreateBoxFormData } from "../lib/types";
 import { useAuth } from "../context/AuthContext";
 import { useTheme } from "../context/ThemeContext";
@@ -116,13 +117,7 @@ export default function CreateScreen() {
   };
 
   const proceedToDetails = () => {
-    if (!capturedImage) {
-      Alert.alert(
-        "Photo Required",
-        "Please add a photo of your box contents first."
-      );
-      return;
-    }
+    // Photo is optional; users can continue without one.
     setStep("details");
   };
 
@@ -175,7 +170,21 @@ export default function CreateScreen() {
       const boxId = uuidv4();
       const qrData = `BinQR:${boxId}`;
 
-      // Prepare box data
+      // Upload photo to Supabase Storage when present. Failure is non-blocking
+      // so the QR / box create flow still completes.
+      let photoUrls: string[] = [];
+      let photoUploadFailed = false;
+      if (capturedImage) {
+        try {
+          const publicUrl = await uploadBoxPhoto(capturedImage);
+          photoUrls = [publicUrl];
+        } catch (uploadError) {
+          console.error("Photo upload failed:", uploadError);
+          photoUploadFailed = true;
+        }
+      }
+
+      // Prepare box data (store public Storage URL, never a local file:// URI)
       const boxData: CreateBoxFormData & { qr_code: string } = {
         name: boxDetails.name.trim(),
         description: boxDetails.description.trim() || undefined,
@@ -186,7 +195,7 @@ export default function CreateScreen() {
               .map((t) => t.trim())
               .filter((t) => t)
           : [],
-        photos: capturedImage ? [capturedImage] : [],
+        photos: photoUrls,
         qr_code: qrData,
       };
 
@@ -196,7 +205,14 @@ export default function CreateScreen() {
       if (savedBox) {
         setGeneratedQR(qrData);
         setStep("review");
-        Alert.alert("Success", "Box created successfully!");
+        if (photoUploadFailed) {
+          Alert.alert(
+            "Box created",
+            "Your box and QR code were saved, but the photo could not be uploaded. You can add a photo later from box details."
+          );
+        } else {
+          Alert.alert("Success", "Box created successfully!");
+        }
       } else {
         Alert.alert("Error", "Failed to create box. Please try again.");
       }
@@ -248,13 +264,22 @@ export default function CreateScreen() {
           </View>
         </View>
       ) : (
-        <TouchableOpacity style={styles.photoButton} onPress={showImageOptions}>
-          <Ionicons name="camera" size={48} color="#2563eb" />
-          <Text style={styles.photoButtonText}>Add Photo</Text>
-          <Text style={styles.photoButtonSubtext}>
-            Tap to take or select photo
-          </Text>
-        </TouchableOpacity>
+        <View style={styles.imageContainer}>
+          <TouchableOpacity style={styles.photoButton} onPress={showImageOptions}>
+            <Ionicons name="camera" size={48} color="#2563eb" />
+            <Text style={styles.photoButtonText}>Add Photo</Text>
+            <Text style={styles.photoButtonSubtext}>
+              Tap to take or select photo (optional)
+            </Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={[styles.continueButton, { marginTop: 20 }]}
+            onPress={proceedToDetails}
+          >
+            <Text style={styles.continueText}>Skip for now</Text>
+            <Ionicons name="arrow-forward" size={20} color="white" />
+          </TouchableOpacity>
+        </View>
       )}
     </View>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Points BinQR mobile at the new Supabase project via local `.env` / EAS secret docs, and uploads box photos to Supabase Storage instead of persisting local `file://` URIs.

## Changes
- **`.env.example`**: blank placeholders plus a commented project-ref example (`yezhteuapxqomspindaz`). No real anon key.
- **`README.md`**: how to create local `.env` with `EXPO_PUBLIC_SUPABASE_URL` / `EXPO_PUBLIC_SUPABASE_ANON_KEY`, and how to set the same vars as EAS Secrets for production builds.
- **`src/lib/storage.ts`**: uploads to `box-photos/{userId}/{uuid}.{ext}`, returns the public URL.
- **`CreateScreen`**: uploads before `saveBox`; photo is optional; upload failure does not block QR / box creation.
- **`BoxDetailsScreen`**: uploads local photos on save before writing `boxes.image_url`.

## Secrets
- No `.env` committed.
- No real anon key in the repo (placeholders / `<your_anon_key>` only).

## Test plan
- [ ] Copy `.env.example` → `.env`, fill URL + anon key for project `yezhteuapxqomspindaz`, restart Expo
- [ ] Create a box with a photo → confirm `boxes.image_url` is an `https://.../storage/v1/object/public/box-photos/...` URL
- [ ] Create a box when offline / with upload failing → box + QR still created, clear alert shown
- [ ] Edit a box photo in Box Details → save stores a public Storage URL
- [ ] Confirm EAS secrets docs match the two `EXPO_PUBLIC_*` vars needed for production builds
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43ad8223-2259-4727-9e89-44acd101395b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43ad8223-2259-4727-9e89-44acd101395b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

