### PR TITLE
Add EAS TestFlight deploy workflow (GitHub Actions)

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -1,0 +1,113 @@
+# Ship iOS production builds to TestFlight via EAS Build + EAS Submit (auto-submit).
+#
+# Required GitHub Actions secrets (same names as hud-code/debt-destroyer ASC setup):
+#   EXPO_TOKEN                          — Expo personal access token (expo.dev → Access tokens)
+#   APP_STORE_CONNECT_API_KEY_ID        — ASC API key ID (maps to EXPO_ASC_KEY_ID)
+#   APP_STORE_CONNECT_API_KEY_ISSUER_ID — ASC API key issuer ID (maps to EXPO_ASC_ISSUER_ID)
+#   APP_STORE_CONNECT_API_KEY_CONTENT   — Full .p8 key file contents (written to EXPO_ASC_API_KEY_PATH)
+#
+# Optional until ascAppId is committed in eas.json:
+#   ASC_APP_ID                          — Numeric App Store Connect app Apple ID (ascAppId)
+#
+# iOS signing credentials (distribution cert, provisioning profile) are managed by EAS,
+# not stored in GitHub. Run a local `eas build -p ios --profile production` once before CI.
+
+name: TestFlight (EAS)
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - "LICENSE"
+      - ".gitignore"
+
+permissions:
+  contents: read
+
+jobs:
+  testflight:
+    name: EAS iOS production → TestFlight
+    runs-on: ubuntu-latest
+    env:
+      ASC_KEY_FILE: ${{ runner.temp }}/AuthKey.p8
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Setup Expo and EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          packager: npm
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Configure ascAppId from secret (optional)
+        env:
+          ASC_APP_ID: ${{ secrets.ASC_APP_ID }}
+        run: |
+          if [ -n "$ASC_APP_ID" ]; then
+            jq --arg id "$ASC_APP_ID" '.submit.production.ios.ascAppId = $id' eas.json > eas.json.tmp
+            mv eas.json.tmp eas.json
+            echo "Set submit.production.ios.ascAppId from ASC_APP_ID secret."
+          else
+            echo "ASC_APP_ID secret not set; using ascAppId from eas.json if present."
+          fi
+
+      - name: Write App Store Connect API key
+        env:
+          APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
+        run: |
+          if [ -z "$APP_STORE_CONNECT_API_KEY_CONTENT" ]; then
+            echo "::error::APP_STORE_CONNECT_API_KEY_CONTENT secret is required for non-interactive submit."
+            exit 1
+          fi
+          printf '%s\n' "$APP_STORE_CONNECT_API_KEY_CONTENT" > "$ASC_KEY_FILE"
+          chmod 600 "$ASC_KEY_FILE"
+
+      - name: EAS Build (iOS) with auto-submit to TestFlight
+        id: eas_build
+        env:
+          EXPO_ASC_API_KEY_PATH: ${{ env.ASC_KEY_FILE }}
+          EXPO_ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          EXPO_ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          # --no-wait: trigger build on EAS cloud and exit (submit runs when build completes).
+          # See https://docs.expo.dev/build/automate-submissions/ and https://docs.expo.dev/build/building-on-ci/
+          BUILD_JSON=$(eas build -p ios --profile production --non-interactive --auto-submit --no-wait --json)
+          echo "$BUILD_JSON" | jq .
+
+          BUILD_URL=$(echo "$BUILD_JSON" | jq -r 'if type == "array" then .[0].buildDetailsPageUrl // .[0].logsUrl else .buildDetailsPageUrl // .logsUrl end // empty')
+          if [ -z "$BUILD_URL" ]; then
+            BUILD_URL=$(echo "$BUILD_JSON" | grep -Eo 'https://expo.dev/[^"]+' | head -1 || true)
+          fi
+
+          if [ -n "$BUILD_URL" ]; then
+            echo "build_url=$BUILD_URL" >> "$GITHUB_OUTPUT"
+            {
+              echo "## EAS iOS build"
+              echo ""
+              echo "Production build triggered with \`--auto-submit\` (TestFlight when the build finishes on EAS)."
+              echo ""
+              echo "**Build:** [$BUILD_URL]($BUILD_URL)"
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::warning::Could not parse build URL from EAS output; check the job logs."
+          fi
+
+      - name: Remove App Store Connect API key
+        if: always()
+        run: rm -f "$ASC_KEY_FILE"

--- a/README.md
+++ b/README.md
@@ -121,6 +121,24 @@ eas secret:create --name EXPO_PUBLIC_SUPABASE_ANON_KEY --value "<your_anon_key>"
 List or update existing secrets with `eas secret:list` / `eas secret:delete` as needed.
 Do not paste real anon keys into git, README examples, or PR descriptions.
 
+### TestFlight CI (GitHub Actions + EAS)
+
+Pushes to `main` (excluding markdown-only changes) and manual **Run workflow** trigger [`.github/workflows/testflight.yml`](.github/workflows/testflight.yml). That workflow runs on `ubuntu-latest`, installs dependencies, and starts an EAS cloud iOS production build with `--auto-submit --no-wait`. When the build finishes on EAS, submission goes to TestFlight using the `production` submit profile in `eas.json`.
+
+**GitHub repository secrets** (Settings → Secrets and variables → Actions):
+
+| Secret | Purpose |
+| --- | --- |
+| `EXPO_TOKEN` | Expo personal access token for EAS CLI in CI |
+| `APP_STORE_CONNECT_API_KEY_ID` | App Store Connect API key ID → `EXPO_ASC_KEY_ID` |
+| `APP_STORE_CONNECT_API_KEY_ISSUER_ID` | ASC issuer ID → `EXPO_ASC_ISSUER_ID` |
+| `APP_STORE_CONNECT_API_KEY_CONTENT` | Full `.p8` key contents (written to a temp file → `EXPO_ASC_API_KEY_PATH`) |
+| `ASC_APP_ID` | *(Optional)* Numeric App Store Connect app Apple ID (`ascAppId`). Required for auto-submit in CI until you commit `submit.production.ios.ascAppId` in `eas.json`. [How to find ascAppId](https://expo.fyi/asc-app-id). |
+
+iOS distribution certificates and provisioning profiles are **not** checked into GitHub. EAS manages credentials remotely after you complete at least one interactive `eas build -p ios --profile production` locally (or via the Expo dashboard).
+
+Set `EXPO_PUBLIC_*` Supabase variables as [EAS Secrets](https://docs.expo.dev/build-reference/variables/) for production builds; the TestFlight workflow does not embed them.
+
 ### Code Sharing with Web App
 
 - Share types from `src/lib/types.ts`

--- a/eas.json
+++ b/eas.json
@@ -16,6 +16,8 @@
     }
   },
   "submit": {
-    "production": {}
+    "production": {
+      "ios": {}
+    }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds CI to ship iOS production builds to TestFlight using **EAS Build + auto-submit** (no macOS runners, Fastlane, or cert/profile secrets in GitHub).

## Changes

- **`.github/workflows/testflight.yml`**
  - Triggers: `push` to `main` (paths-ignore for markdown/docs noise) + `workflow_dispatch`
  - `ubuntu-latest`, Node 22, `expo/expo-github-action@v8` with `eas-version: latest` and `EXPO_TOKEN`
  - Writes ASC `.p8` from `APP_STORE_CONNECT_API_KEY_CONTENT`; maps debt-destroyer secret names to Expo CI env vars (`EXPO_ASC_KEY_ID`, `EXPO_ASC_ISSUER_ID`, `EXPO_ASC_API_KEY_PATH`)
  - Optional `ASC_APP_ID` → `eas.json` `submit.production.ios.ascAppId` via `jq`
  - `eas build -p ios --profile production --non-interactive --auto-submit --no-wait` with build URL in job summary
  - Always deletes temp `.p8`

- **`eas.json`**: `submit.production.ios` object scaffold (no committed `ascAppId`)

- **`README.md`**: TestFlight CI overview and required GitHub secrets

## Enabling deploys

Add repository secrets: `EXPO_TOKEN`, `APP_STORE_CONNECT_API_KEY_ID`, `APP_STORE_CONNECT_API_KEY_ISSUER_ID`, `APP_STORE_CONNECT_API_KEY_CONTENT`, and `ASC_APP_ID` until `ascAppId` is in `eas.json`. Complete one interactive `eas build -p ios --profile production` so EAS has iOS credentials.

## References

- [Trigger builds from CI](https://docs.expo.dev/build/building-on-ci/)
- [Automate submissions](https://docs.expo.dev/build/automate-submissions/)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af9da851-c86c-472e-a513-25a26ffed639?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af9da851-c86c-472e-a513-25a26ffed639&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

