### PR TITLE
fix(ci): resolve testflight workflow parse error for runner.temp at job env

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -32,8 +32,6 @@ jobs:
   testflight:
     name: EAS iOS production → TestFlight
     runs-on: ubuntu-latest
-    env:
-      ASC_KEY_FILE: ${{ runner.temp }}/AuthKey.p8
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -74,13 +72,14 @@ jobs:
             echo "::error::APP_STORE_CONNECT_API_KEY_CONTENT secret is required for non-interactive submit."
             exit 1
           fi
+          ASC_KEY_FILE="$RUNNER_TEMP/AuthKey.p8"
           printf '%s\n' "$APP_STORE_CONNECT_API_KEY_CONTENT" > "$ASC_KEY_FILE"
           chmod 600 "$ASC_KEY_FILE"
 
       - name: EAS Build (iOS) with auto-submit to TestFlight
         id: eas_build
         env:
-          EXPO_ASC_API_KEY_PATH: ${{ env.ASC_KEY_FILE }}
+          EXPO_ASC_API_KEY_PATH: ${{ runner.temp }}/AuthKey.p8
           EXPO_ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           EXPO_ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
         run: |
@@ -110,4 +109,4 @@ jobs:
 
       - name: Remove App Store Connect API key
         if: always()
-        run: rm -f "$ASC_KEY_FILE"
+        run: rm -f "$RUNNER_TEMP/AuthKey.p8"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
`.github/workflows/testflight.yml` failed to parse because job-level `env` referenced `${{ runner.temp }}`, which is not allowed in that context.

## Fix
- Remove job-level `ASC_KEY_FILE` env.
- Write the `.p8` to `$RUNNER_TEMP/AuthKey.p8` in the write step.
- Set `EXPO_ASC_API_KEY_PATH` to `${{ runner.temp }}/AuthKey.p8` in the EAS build step `env` (step-level `runner` context is valid).
- Delete the key with `rm -f "$RUNNER_TEMP/AuthKey.p8"` in the cleanup step.

Secrets mapping and `eas build ... --auto-submit --no-wait` behavior unchanged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-905d5d6e-1039-4cfc-a91d-c559e42460b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-905d5d6e-1039-4cfc-a91d-c559e42460b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

