### PR TITLE
fix(ios): EAS Xcode 26+ image for App Store SDK requirement

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -9,15 +9,23 @@
       "distribution": "internal"
     },
     "preview": {
-      "distribution": "internal"
+      "distribution": "internal",
+      "ios": {
+        "image": "latest"
+      }
     },
     "production": {
-      "autoIncrement": true
+      "autoIncrement": true,
+      "ios": {
+        "image": "latest"
+      }
     }
   },
   "submit": {
     "production": {
-      "ios": {}
+      "ios": {
+        "ascAppId": "6749247446"
+      }
     }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

App Store Connect rejects BinQR IPAs built with the **iOS 18.5 SDK**. Upload via altool fails with:

> This app was built with the iOS 18.5 SDK. All iOS and iPadOS apps must be built with the **iOS 26 SDK or later**, included in **Xcode 26 or later**.

## Change

- Set `build.production.ios.image` and `build.preview.ios.image` to **`latest`** so EAS uses a current macOS/Xcode stack (Xcode 26+ with iOS 26 SDK). This project is on **Expo SDK 53**; we did not bump the Expo SDK in this PR.
- Set `submit.production.ios.ascAppId` to **`6749247446`** so CI auto-submit can target the correct App Store Connect app without relying only on the `ASC_APP_ID` secret (secret injection can remain).

## After merge

**A new production iOS build is required** (e.g. `eas build --platform ios --profile production`) and resubmit to App Store Connect. Existing IPAs built on the old image will continue to be rejected.

## Out of scope

- App icon changes (handled separately)
- No secrets or `.env` changes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff73c176-0def-4f71-98ee-8e747fc85b96?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff73c176-0def-4f71-98ee-8e747fc85b96&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

